### PR TITLE
Fix crash when using random select from a playlist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: cache
         key: build
@@ -24,13 +24,13 @@ jobs:
       run: cmake --build build --config Release
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-artifacts
         path: build/Release/playlister3.dll
 
     - name: Create release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: build/Release/playlister3.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(playlister3 VERSION 4.0.2.0 LANGUAGES CXX)
+project(playlister3 VERSION 4.0.3.0 LANGUAGES CXX)
 
 include(cmake/get_cpm.cmake)
 include(cmake/GetGitRevisionDescription.cmake)

--- a/src/init.cc
+++ b/src/init.cc
@@ -62,9 +62,7 @@ namespace playlister
     bar_state_t* bar_state = nullptr;
     auto text_category_id = -1;
     auto last_category_id = -1;
-    auto last_music_difficulty_p1 = -1;
-    auto last_music_difficulty_p2 = -1;
-    music_entry_t* last_music_entry_ptr = nullptr;
+    auto last_category_bar_id = -1;
 
     // hooks
     auto music_select_init_hook = safetyhook::InlineHook {};
@@ -864,9 +862,7 @@ namespace playlister
             +[] (void* a1, int a2)
         {
             last_category_id = -1;
-            last_music_difficulty_p1 = -1;
-            last_music_difficulty_p2 = -1;
-            last_music_entry_ptr = nullptr;
+            last_category_bar_id = -1;
 
             if (!in_playlist_mode || !is_valid_game_type())
                 return save_category_hook.call<void*, void*, int>(a1, a2);
@@ -884,12 +880,8 @@ namespace playlister
                 {
                     spdlog::debug("Storing previous position...");
 
-                    auto const index = category->active_bar - 1;
-
                     last_category_id = category->meta.id;
-                    last_music_difficulty_p1 = category->bars[index].bar->p1_difficulty_original;
-                    last_music_difficulty_p2 = category->bars[index].bar->p2_difficulty_original;
-                    last_music_entry_ptr = category->bars[index].bar->music_entry_ptr;
+                    last_category_bar_id = category->active_bar;
 
                     break;
                 }
@@ -926,36 +918,15 @@ namespace playlister
                 spdlog::debug("Sorting folder...");
                 sort_bars(category, music_select_game_data->sort_mode, true);
 
-                spdlog::debug("Searching for '{}'...", last_music_entry_ptr->title_ascii);
+                category->is_open = true;
 
-                for (auto j = 0; j < BAR_COUNT; ++j)
-                {
-                    if (!category->bars[j].bar)
-                        break;
-                    if (category->bars[j].bar->music_entry_ptr != last_music_entry_ptr)
-                        continue;
-                    if (category->bars[j].bar->p1_difficulty_original != last_music_difficulty_p1)
-                        continue;
-                    if (category->bars[j].bar->p2_difficulty_original != last_music_difficulty_p2)
-                        continue;
+                // todo: actually test this (with and without cursor lock hex edit enabled)
+                if (config.get("cursor lock", false))
+                    category->active_bar = last_category_bar_id;
 
-                    spdlog::debug("Restored previous position successfully!");
-
-                    category->is_open = true;
-                    category->active_bar = 0;
-
-                    // todo: actually test this (with and without cursor lock hex edit enabled)
-                    if (config.get("cursor lock", false))
-                        category->active_bar = j + 1;
-
-                    // open this category folder
-                    bar_state->active_bar = i;
-                    bar_state->is_folder_open = true;
-
-                    break;
-                }
-
-                break;
+                // open this category folder
+                bar_state->active_bar = i;
+                bar_state->is_folder_open = true;
             }
 
             return (void*) category_game_data;
@@ -973,9 +944,7 @@ namespace playlister
 
             text_category_id = -1;
             last_category_id = -1;
-            last_music_difficulty_p1 = -1;
-            last_music_difficulty_p2 = -1;
-            last_music_entry_ptr = nullptr;
+            last_category_bar_id = -1;
 
             return reset_state_hook.call<void*>();
         });


### PR DESCRIPTION
Refactors cursor lock to save the current bar index before the music select scene is destructed.

Since we alter the category data contents with no regard for game restrictions, I can't think of any scenario where the contents of a category would vary between stages, so this should be fairly reliable.

This also fixes a crash where the music data pointer, which isn't set to a valid address on the random select bar, would be saved and then dereferenced in the 'Searching for (music title)' log message.

Waiting for some external testing, then will be released as v4.0.3.0.