### PR TITLE
DP BATTLE mode fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(playlister3 VERSION 4.0.3.0 LANGUAGES CXX)
+project(playlister3 VERSION 4.1.0.0 LANGUAGES CXX)
 
 include(cmake/get_cpm.cmake)
 include(cmake/GetGitRevisionDescription.cmake)

--- a/res/playlister.rc
+++ b/res/playlister.rc
@@ -22,7 +22,7 @@ BEGIN
       VALUE "FileDescription", "playlister"
       VALUE "FileVersion", GIT_COMMIT_HASH
       VALUE "InternalName", "playlister"
-      VALUE "LegalCopyright", "© 2024, aixxe.net"
+      VALUE "LegalCopyright", "© 2025, aixxe.net"
       VALUE "OriginalFilename", "playlister.dll"
       VALUE "ProductName", "playlister"
       VALUE "ProductVersion", RC_FILEVERSION_STRING

--- a/src/init.cc
+++ b/src/init.cc
@@ -36,6 +36,7 @@ namespace playlister
     state_t* state = nullptr;
     std::uint64_t* buttons = nullptr;
     music_data_t* music_data = nullptr;
+    std::uint32_t* mselect_style = nullptr;
     player_scores_t* player_scores_p1 = nullptr;
     player_scores_t* player_scores_p2 = nullptr;
     CCategoryGameData* category_game_data = nullptr;
@@ -170,7 +171,7 @@ namespace playlister
         // bar count is for the current play style
         auto populated_bar_count = 0;
 
-        for (auto const& category: category_game_data->populated_categories[state->play_style])
+        for (auto const& category: category_game_data->populated_categories[*mselect_style])
             if (category)
                 populated_bar_count++;
 
@@ -410,13 +411,13 @@ namespace playlister
 
         for (auto const& playlist: playlist_data)
         {
-            if (playlist.play_style != state->play_style)
+            if (playlist.play_style != *mselect_style)
                 continue;
 
             if (i == OVERRIDE_CATEGORY_ID)
                 ++i;
 
-            create_populated_category(state->play_style, i, playlist);
+            create_populated_category(*mselect_style, i, playlist);
 
             i++;
 
@@ -457,6 +458,7 @@ namespace playlister
         // game context offsets
         state = reinterpret_cast<decltype(state)>(addr.GAME_STATE);
         buttons = reinterpret_cast<decltype(buttons)>(addr.BUTTON_STATE);
+        mselect_style = reinterpret_cast<decltype(mselect_style)>(addr.MSELECT_STYLE);
         player_scores_p1 = reinterpret_cast<decltype(player_scores_p1)>(addr.SCORES_P1);
         player_scores_p2 = reinterpret_cast<decltype(player_scores_p2)>(addr.SCORES_P2);
         category_definitions = reinterpret_cast<decltype(category_definitions)>(addr.CATEGORY_DEFS);
@@ -534,7 +536,7 @@ namespace playlister
             if (in_playlist_mode || !is_valid_game_type())
                 return;
 
-            auto const category = category_game_data->populated_categories[state->play_style][ctx.rdx];
+            auto const category = category_game_data->populated_categories[*mselect_style][ctx.rdx];
 
             // ignore if this isn't our "fake" category
             if (category->id != target_category_id)
@@ -588,7 +590,7 @@ namespace playlister
                 auto const count_p1 = bits[1] + bits[3] + bits[5];
                 auto const count_p2 = bits[8] + bits[10] + bits[12];
 
-                if (state->play_style == STYLE_SP)
+                if (*mselect_style == STYLE_SP)
                 {
                     if (state->is_active[PLAYER_1] && count_p1 == 1) return;
                     if (state->is_active[PLAYER_2] && count_p2 == 1) return;
@@ -620,9 +622,9 @@ namespace playlister
 
             for (auto i = 0; i < CATEGORY_COUNT; ++i)
             {
-                if (category_game_data->populated_categories[state->play_style][i] == nullptr)
+                if (category_game_data->populated_categories[*mselect_style][i] == nullptr)
                     continue;
-                if (category_game_data->populated_categories[state->play_style][i]->id == target_category_id)
+                if (category_game_data->populated_categories[*mselect_style][i]->id == target_category_id)
                 {
                     spdlog::debug("Reselected inserted category.");
                     bar_state->active_bar = i;
@@ -663,7 +665,7 @@ namespace playlister
                 width += 20.f;
 
                 // resolve to the underlying playlist
-                auto const& category = category_game_data->categories[state->play_style][text_category_id];
+                auto const& category = category_game_data->categories[*mselect_style][text_category_id];
                 auto const& playlist = static_cast<playlist_t*>(category.meta.userdata);
 
                 auto const has_texture = config.get("custom textures", false) && !playlist->bar_texture.empty();
@@ -695,7 +697,7 @@ namespace playlister
             }
 
             // avoid pulling the category pointer from the stack by using the active bar instead
-            auto const& category = category_game_data->populated_categories[state->play_style][bar_state->active_bar];
+            auto const& category = category_game_data->populated_categories[*mselect_style][bar_state->active_bar];
             auto const& playlist = static_cast<playlist_t*>(category->meta.userdata);
 
             if (!playlist->voice.empty() && category_voices.contains(playlist->voice))
@@ -713,7 +715,7 @@ namespace playlister
 
             auto result = "SELECT FROM CUSTOM CATEGORY";
 
-            auto const& category = category_game_data->populated_categories[state->play_style][bar_state->active_bar];
+            auto const& category = category_game_data->populated_categories[*mselect_style][bar_state->active_bar];
             auto const& playlist = static_cast<playlist_t*>(category->meta.userdata);
 
             if (playlist && !playlist->ticker_text.empty())
@@ -750,7 +752,7 @@ namespace playlister
             if (target_category_id == -1)
                 return result;
 
-            spdlog::debug("Setting up categories for {}...", state->play_style == STYLE_SP ? "SP": "DP");
+            spdlog::debug("Setting up categories for {}...", *mselect_style == STYLE_SP ? "SP": "DP");
 
             for (auto i = 0; i < STYLE_COUNT; ++i)
             {
@@ -846,7 +848,7 @@ namespace playlister
 
             for (auto k = 0; k < CATEGORY_COUNT; ++k)
             {
-                if (!a1->populated_categories[state->play_style][k])
+                if (!a1->populated_categories[*mselect_style][k])
                     break;
                 a1->bar_count++;
             }
@@ -871,7 +873,7 @@ namespace playlister
 
             for (auto i = 0; i < CATEGORY_COUNT; ++i)
             {
-                auto category = category_game_data->populated_categories[state->play_style][i];
+                auto category = category_game_data->populated_categories[*mselect_style][i];
 
                 if (!category)
                     break;
@@ -906,7 +908,7 @@ namespace playlister
 
             for (auto i = 0; i < CATEGORY_COUNT; ++i)
             {
-                auto category = category_game_data->populated_categories[state->play_style][i];
+                auto category = category_game_data->populated_categories[*mselect_style][i];
 
                 if (!category)
                     break;

--- a/src/offsets.h.in
+++ b/src/offsets.h.in
@@ -43,6 +43,7 @@ struct offsets
     std::uint8_t* MSELECT_DATA;
     std::uint8_t* GAME_STATE;
     std::uint8_t* BUTTON_STATE;
+    std::uint8_t* MSELECT_STYLE;
 };
 
 auto inline resolve_offsets(std::uint8_t* base) -> std::optional<offsets>

--- a/src/offsets/2024082600-010.cc
+++ b/src/offsets/2024082600-010.cc
@@ -40,4 +40,5 @@ versions.push_back({
     .MSELECT_DATA            = base + 0x69FAC68,
     .GAME_STATE              = base + 0x6C1ED80,
     .BUTTON_STATE            = base + 0x70DDF3C,
+    .MSELECT_STYLE           = base + 0x69DEEE0,
 });

--- a/src/offsets/2024082600-012.cc
+++ b/src/offsets/2024082600-012.cc
@@ -40,4 +40,5 @@ versions.push_back({
     .MSELECT_DATA            = base + 0x68F9C28,
     .GAME_STATE              = base + 0x6B1DD40,
     .BUTTON_STATE            = base + 0x6FDCEFC,
+    .MSELECT_STYLE           = base + 0x68DDEA0,
 });


### PR DESCRIPTION
Initial attempt at fixing another DP related bug report. Opening the playlist folder when the BATTLE modifier is enabled will either show DP playlists with incorrect contents or immediately crash depending on how many playlists exist for each style.

Introduces a new variable which is set to `0` for SP, `1` for DP, and `0` again for DP BATTLE. Music select is supposed to show SP categories when DP BATTLE is active, so relying on `state->play_style` as we've been doing until now has been incorrect.